### PR TITLE
Add a `collectiveconsciousness' strategy

### DIFF
--- a/strategies/collectiveconsciousness.py
+++ b/strategies/collectiveconsciousness.py
@@ -1,0 +1,13 @@
+import prisonerlib
+
+
+class Prisoner(prisonerlib.Prisoner):
+    def __init__(self, *args, **kwargs):
+        super(Prisoner, self).__init__(*args, **kwargs)
+        self.__memory = set()
+
+    def visit(self, light_bulb, day):
+        if light_bulb.on:
+            self.__memory.add((day - 1) % prisonerlib.NUM_PRISONERS)
+        light_bulb.on = self.pid == day % prisonerlib.NUM_PRISONERS
+        return len(self.__memory) == prisonerlib.NUM_PRISONERS


### PR DESCRIPTION
The `collectiveconsciousness` strategy works by each prisoner keeping
their own log of what days they have seen the light on, and only
turning the light on when the day corresponds to their own ID.
